### PR TITLE
Dev server compatibility changes 

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ AssetsWebpackPlugin.prototype = {
   apply: function (compiler) {
     var self = this
 
-    compiler.plugin('after-emit', function (compilation, callback) {
+    compiler.plugin('emit', function (compilation, callback) {
       var output = {}
       var options = compiler.options
       var stats = compilation.getStats().toJson({
@@ -87,6 +87,17 @@ AssetsWebpackPlugin.prototype = {
         }
         callback()
       })
+
+      var outputString = JSON.stringify(output, null, self.options.prettyPrint ? 2 : null)
+
+      compilation.assets[self.options.filename] = {
+        source: function() {
+          return outputString
+        },
+        size: function() {
+          return outputString.length
+        }
+      }
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "assets-webpack-plugin",
+  "name": "superhuman-assets-webpack-plugin",
   "version": "3.4.0",
   "description": "Emits a json file with assets paths",
   "main": "index.js",


### PR DESCRIPTION
Issues if we want to merge this back to base fork. Need to clearly document that this plugin needs to be run after all the other plugins in webpack dev server, which is why i am not bullish on this fix and would expect correct fix would be in 'webpack-dev-server'.
